### PR TITLE
Remove user ID from generated short URLs

### DIFF
--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -17,8 +17,8 @@ export const LinkCard: React.FC<LinkCardProps> = ({ link, onEdit, onDelete, onCo
   const shortUrl =
     link.shortUrl ||
     `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}/${
-      link.userId
-    }/${link.customAlias || link.shortCode}`;
+      link.customAlias || link.shortCode
+    }`;
   const displayUrl = showFullUrl ? link.originalUrl : 
     link.originalUrl.length > 50 ? link.originalUrl.substring(0, 50) + '...' : link.originalUrl;
 

--- a/src/hooks/useLinks.ts
+++ b/src/hooks/useLinks.ts
@@ -39,11 +39,9 @@ export const useLinks = (userId: string | null) => {
         return {
           id: doc.id,
           ...data,
-          shortUrl:
-            data.shortUrl ||
-            `${basePath.replace(/\/$/, '')}/${data.userId}/${
-              data.customAlias || data.shortCode
-            }`,
+          shortUrl: `${basePath.replace(/\/$/, '')}/${
+            data.customAlias || data.shortCode
+          }`,
           openInNewTab: data.openInNewTab ?? true,
           createdAt: data.createdAt?.toDate() || new Date(),
           updatedAt: data.updatedAt?.toDate() || new Date(),
@@ -72,7 +70,7 @@ export const useLinks = (userId: string | null) => {
 
     try {
       const basePath = window.location.origin + import.meta.env.BASE_URL;
-      const shortUrl = `${basePath.replace(/\/$/, '')}/${userId}/${linkData.shortCode}`;
+      const shortUrl = `${basePath.replace(/\/$/, '')}/${linkData.shortCode}`;
       await addDoc(collection(db, 'links'), {
         ...linkData,
         shortUrl,


### PR DESCRIPTION
## Summary
- generate short URLs without embedding Google user ID
- drop user ID from LinkCard fallback URLs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6891de236564832db0a575a85c312442